### PR TITLE
Add support for pyscopg3

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11"]
         dj-version: ["3.2.*", "4.0.*", "4.1.*", "4.2.*"]
+        psycopg: ["psycopg2", "psycopg[binary,pool]"]
 
     services:
       postgres:
@@ -42,6 +43,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install 'django==${{ matrix.dj-version }}'
+        pip install ${{ matrix.psycopg }}
     - name: Run Tests
       run: |
         DATABASE_URL=psql://local:dev@localhost:5432/django_audimatic coverage run -p manage.py migrate

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 django = ">=3.2.23,<4.3"
 django-nonrelated-inlines = "*"
 django-pgtrigger = "*"
-psycopg = "*"
 
 [dev-packages]
 build = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
   "django>=3.2",
   "django-nonrelated-inlines",
   "django-pgtrigger",
-  "psycopg"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add psycopg3 to the testing matrix in the CI workflow to ensure compatibility.