### PR TITLE
Add support for Django 5.x

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -15,15 +15,15 @@ jobs:
         python-version: [3.8, 3.9, "3.10", "3.11"]
         dj-version: ["3.2.*", "4.0.*", "4.1.*", "4.2.*", "5.0.*", "5.1.*"]
         psycopg: ["psycopg2", "psycopg[binary,pool]"]
-      exclude:
-        - dj-version: "5.0.*"
-          python-version: 3.8
-        - dj-version: "5.0.*"
-          python-version: 3.9
-        - dj-version: "5.1.*"
-          python-version: 3.8
-        - dj-version: "5.1.*"
-          python-version: 3.9
+        exclude:
+          - dj-version: "5.0.*"
+            python-version: 3.8
+          - dj-version: "5.0.*"
+            python-version: 3.9
+          - dj-version: "5.1.*"
+            python-version: 3.8
+          - dj-version: "5.1.*"
+            python-version: 3.9
     services:
       postgres:
         image: postgres:latest

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11"]
-        dj-version: ["3.2.*", "4.0.*", "4.1.*", "4.2.*"]
+        dj-version: ["3.2.*", "4.0.*", "4.1.*", "4.2.*", "5.0.*", "5.1.*"]
         psycopg: ["psycopg2", "psycopg[binary,pool]"]
 
     services:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -15,7 +15,15 @@ jobs:
         python-version: [3.8, 3.9, "3.10", "3.11"]
         dj-version: ["3.2.*", "4.0.*", "4.1.*", "4.2.*", "5.0.*", "5.1.*"]
         psycopg: ["psycopg2", "psycopg[binary,pool]"]
-
+      exclude:
+        - dj-version: "5.0.*"
+          python-version: 3.8
+        - dj-version: "5.0.*"
+          python-version: 3.9
+        - dj-version: "5.1.*"
+          python-version: 3.8
+        - dj-version: "5.1.*"
+          python-version: 3.9
     services:
       postgres:
         image: postgres:latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-audimatic"
-version = "0.3.1"
+version = "0.4.0"
 authors = [
   { name="Bill Schumacher", email="34168009+BillSchumacher@users.noreply.github.com" },
 ]
@@ -20,6 +20,8 @@ classifiers = [
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add Django 5.0 and 5.1 to the CI testing matrix.